### PR TITLE
Fix errors in x86 Full System Simulation configuration files in Part IV

### DIFF
--- a/_static/scripts/part4/system.py
+++ b/_static/scripts/part4/system.py
@@ -104,6 +104,7 @@ class MySystem(LinuxX86System):
 
         self.cpu = AtomicSimpleCPU()
         self.mem_mode = 'atomic'
+        self.cpu.createThreads()
 
     def setDiskImage(self, img_path):
         """ Set the disk image

--- a/_static/scripts/part4/x86.py
+++ b/_static/scripts/part4/x86.py
@@ -76,12 +76,12 @@ def init_fs(system, membus):
     # Add a tiny cache to the IO bus.
     # This cache is required for the classic memory model to mantain coherence
     system.iocache = Cache(assoc=8,
-                        hit_latency = 50,
+                        tag_latency = 50,
+                        data_latency = 50,
                         response_latency = 50,
                         mshrs = 20,
                         size = '1kB',
                         tgts_per_mshr = 12,
-                        forward_snoops = False,
                         addr_ranges = system.mem_ranges)
     system.iocache.cpu_side = system.iobus.master
     system.iocache.mem_side = system.membus.slave

--- a/_static/scripts/part4/x86_mp.py
+++ b/_static/scripts/part4/x86_mp.py
@@ -75,12 +75,12 @@ def init_fs(system, membus, cpus=1):
     # Add a tiny cache to the IO bus.
     # This cache is required for the classic memory model to mantain coherence
     system.iocache = Cache(assoc=8,
-                        hit_latency = 50,
+                        tag_latency = 50,
+                        data_latency = 50,
                         response_latency = 50,
                         mshrs = 20,
                         size = '1kB',
                         tgts_per_mshr = 12,
-			forward_snoops=False,
                         addr_ranges = system.mem_ranges)
     system.iocache.cpu_side = system.iobus.master
     system.iocache.mem_side = system.membus.slave

--- a/part4/fs_config.rst
+++ b/part4/fs_config.rst
@@ -210,6 +210,7 @@ If you want to use this configuration for real simulation, you need to change th
         """ Create a CPU for the system """
         self.cpu = AtomicSimpleCPU()
         self.mem_mode = 'atomic'
+        self.cpu.createThreads()
 
 After creating the disk image and the CPU, we next create the cache hierarchy.
 For this configuration, we are going to use the simple two-level cache hierarchy from :ref:`cache-config-chapter`.
@@ -329,12 +330,12 @@ For the details, see the Intel x86 architecture manual and the gem5 source code.
         # Add a tiny cache to the IO bus.
         # This cache is required for the classic memory model to maintain coherence
         system.iocache = Cache(assoc=8,
-                            hit_latency = 50,
+                            tag_latency = 50,
+                            data_latency = 50,
                             response_latency = 50,
                             mshrs = 20,
                             size = '1kB',
                             tgts_per_mshr = 12,
-                            forward_snoops = False,
                             addr_ranges = system.mem_ranges)
         system.iocache.cpu_side = system.iobus.master
         system.iocache.mem_side = system.membus.slave


### PR DESCRIPTION
* Call BaseCPU::createThreads in system.py after creating AtomicSimpleCPU.
    Since https://www.mail-archive.com/gem5-dev@gem5.org/msg23775.html was
    merged to GEM5, it is necessary to call createThreads function to select
    default ISA for an architecture. Otherwise the following error is shown:
      "fatal: Number of ISAs (0) assigned to the CPU does not equal number of
       threads (1)."
    This is fixed by calling createThreads after AtomicSimpleCPU instance is
    created.

* Fix arguments for Cache constructor in x86.py and x86_mp.py
    This is a fix in configuration file as suggested in
    https://www.mail-archive.com/gem5-users@gem5.org/msg14311.html

Signed-off-by: Talha Imran <m.talha.imran01@gmail.com>