### PR TITLE
Fix tutorial

### DIFF
--- a/_static/scripts/part2/memoryobject/simple_memobj.cc
+++ b/_static/scripts/part2/memoryobject/simple_memobj.cc
@@ -41,22 +41,8 @@ SimpleMemobj::SimpleMemobj(SimpleMemobjParams *params) :
 {
 }
 
-BaseMasterPort&
-SimpleMemobj::getMasterPort(const std::string& if_name, PortID idx)
-{
-    panic_if(idx != InvalidPortID, "This object doesn't support vector ports");
-
-    // This is the name from the Python SimObject declaration (SimpleMemobj.py)
-    if (if_name == "mem_side") {
-        return memPort;
-    } else {
-        // pass it along to our super class
-        return MemObject::getMasterPort(if_name, idx);
-    }
-}
-
-BaseSlavePort&
-SimpleMemobj::getSlavePort(const std::string& if_name, PortID idx)
+Port&
+SimpleMemobj::getPort(const std::string& if_name, PortID idx)
 {
     panic_if(idx != InvalidPortID, "This object doesn't support vector ports");
 
@@ -65,9 +51,11 @@ SimpleMemobj::getSlavePort(const std::string& if_name, PortID idx)
         return instPort;
     } else if (if_name == "data_port") {
         return dataPort;
+    } else if (if_name == "mem_side") {
+        return memPort;
     } else {
         // pass it along to our super class
-        return MemObject::getSlavePort(if_name, idx);
+        return MemObject::getPort(if_name, idx);
     }
 }
 

--- a/_static/scripts/part2/memoryobject/simple_memobj.hh
+++ b/_static/scripts/part2/memoryobject/simple_memobj.hh
@@ -237,7 +237,7 @@ class SimpleMemobj : public MemObject
     SimpleMemobj(SimpleMemobjParams *params);
 
     /**
-     * Get a master port with a given name and index. This is used at
+     * Get a port with a given name and index. This is used at
      * binding time and returns a reference to a protocol-agnostic
      * base master port.
      *
@@ -246,21 +246,8 @@ class SimpleMemobj : public MemObject
      *
      * @return A reference to the given port
      */
-    BaseMasterPort& getMasterPort(const std::string& if_name,
+    Port& getPort(const std::string& if_name,
                                   PortID idx = InvalidPortID) override;
-
-    /**
-     * Get a slave port with a given name and index. This is used at
-     * binding time and returns a reference to a protocol-agnostic
-     * base master port.
-     *
-     * @param if_name Port name
-     * @param idx Index in the case of a VectorPort
-     *
-     * @return A reference to the given port
-     */
-    BaseSlavePort& getSlavePort(const std::string& if_name,
-                                PortID idx = InvalidPortID) override;
 };
 
 

--- a/_static/scripts/part2/memoryobject/simple_memobj.py
+++ b/_static/scripts/part2/memoryobject/simple_memobj.py
@@ -94,6 +94,6 @@ root = Root(full_system = False, system = system)
 # instantiate all of the objects we've created above
 m5.instantiate()
 
-print "Beginning simulation!"
+print('Beginning simulation!')
 exit_event = m5.simulate()
-print 'Exiting @ tick %i because %s' % (m5.curTick(), exit_event.getCause())
+print('Exiting @ tick %i because %s' % (m5.curTick(), exit_event.getCause()))

--- a/_static/scripts/part2/parameters/hello_goodbye.py
+++ b/_static/scripts/part2/parameters/hello_goodbye.py
@@ -52,6 +52,6 @@ root.hello.goodbye_object = GoodbyeObject(buffer_size='100B')
 # instantiate all of the objects we've created above
 m5.instantiate()
 
-print "Beginning simulation!"
+print('Beginning simulation!')
 exit_event = m5.simulate()
-print 'Exiting @ tick %i because %s' % (m5.curTick(), exit_event.getCause())
+print('Exiting @ tick %i because %s' % (m5.curTick(), exit_event.getCause()))

--- a/_static/scripts/part2/parameters/hello_object.cc
+++ b/_static/scripts/part2/parameters/hello_object.cc
@@ -34,7 +34,7 @@
 HelloObject::HelloObject(HelloObjectParams *params) :
     SimObject(params),
     event(*this),
-    goodbye(*params->goodbye_object),
+    goodbye(params->goodbye_object),
     myName(params->name),
     latency(params->time_to_wait),
     timesLeft(params->number_of_fires)
@@ -56,7 +56,7 @@ HelloObject::processEvent()
 
     if (timesLeft <= 0) {
         DPRINTF(Hello, "Done firing!\n");
-        goodbye.sayGoodbye(myName);
+        goodbye->sayGoodbye(myName);
     } else {
         schedule(event, curTick() + latency);
     }

--- a/_static/scripts/part2/parameters/hello_object.hh
+++ b/_static/scripts/part2/parameters/hello_object.hh
@@ -45,7 +45,7 @@ class HelloObject : public SimObject
     EventWrapper<HelloObject, &HelloObject::processEvent> event;
 
     /// Pointer to the corresponding GoodbyeObject. Set via Python
-    GoodbyeObject& goodbye;
+    GoodbyeObject* goodbye;
 
     /// The name of this object in the Python config file
     std::string myName;

--- a/_static/scripts/part2/simplecache/simple_cache.cc
+++ b/_static/scripts/part2/simplecache/simple_cache.cc
@@ -374,7 +374,7 @@ SimpleCache::insert(PacketPtr pkt)
 
         // Write back the data.
         // Create a new request-packet pair
-        RequestPtr req = new Request(block->first, blockSize, 0, 0);
+        RequestPtr req(new Request(block->first, blockSize, 0, 0));
         PacketPtr new_pkt = new Packet(req, MemCmd::WritebackDirty, blockSize);
         new_pkt->dataDynamic(block->second); // This will be deleted later
 

--- a/_static/scripts/part2/simplecache/simple_cache.cc
+++ b/_static/scripts/part2/simplecache/simple_cache.cc
@@ -51,30 +51,18 @@ SimpleCache::SimpleCache(SimpleCacheParams *params) :
     }
 }
 
-BaseMasterPort&
-SimpleCache::getMasterPort(const std::string& if_name, PortID idx)
-{
-    panic_if(idx != InvalidPortID, "This object doesn't support vector ports");
-
-    // This is the name from the Python SimObject declaration in SimpleCache.py
-    if (if_name == "mem_side") {
-        return memPort;
-    } else {
-        // pass it along to our super class
-        return MemObject::getMasterPort(if_name, idx);
-    }
-}
-
-BaseSlavePort&
-SimpleCache::getSlavePort(const std::string& if_name, PortID idx)
+Port&
+SimpleCache::getPort(const std::string& if_name, PortID idx)
 {
     // This is the name from the Python SimObject declaration (SimpleMemobj.py)
     if (if_name == "cpu_side" && idx < cpuPorts.size()) {
         // We should have already created all of the ports in the constructor
         return cpuPorts[idx];
+    } else if (if_name == "mem_side") {
+        return memPort;
     } else {
         // pass it along to our super class
-        return MemObject::getSlavePort(if_name, idx);
+        return MemObject::getPort(if_name, idx);
     }
 }
 

--- a/_static/scripts/part2/simplecache/simple_cache.hh
+++ b/_static/scripts/part2/simplecache/simple_cache.hh
@@ -330,7 +330,7 @@ class SimpleCache : public MemObject
     SimpleCache(SimpleCacheParams *params);
 
     /**
-     * Get a master port with a given name and index. This is used at
+     * Get a port with a given name and index. This is used at
      * binding time and returns a reference to a protocol-agnostic
      * base master port.
      *
@@ -339,21 +339,8 @@ class SimpleCache : public MemObject
      *
      * @return A reference to the given port
      */
-    virtual BaseMasterPort& getMasterPort(const std::string& if_name,
-                                          PortID idx = InvalidPortID) override;
-
-    /**
-     * Get a slave port with a given name and index. This is used at
-     * binding time and returns a reference to a protocol-agnostic
-     * base master port.
-     *
-     * @param if_name Port name
-     * @param idx Index in the case of a VectorPort
-     *
-     * @return A reference to the given port
-     */
-    virtual BaseSlavePort& getSlavePort(const std::string& if_name,
-                                        PortID idx = InvalidPortID) override;
+    Port& getPort(const std::string& if_name,
+                                  PortID idx = InvalidPortID) override;
 
     /**
      * Register the stats

--- a/_static/scripts/part2/simplecache/simple_cache.py
+++ b/_static/scripts/part2/simplecache/simple_cache.py
@@ -96,6 +96,6 @@ root = Root(full_system = False, system = system)
 # instantiate all of the objects we've created above
 m5.instantiate()
 
-print "Beginning simulation!"
+print('Beginning simulation!')
 exit_event = m5.simulate()
-print 'Exiting @ tick %i because %s' % (m5.curTick(), exit_event.getCause())
+print('Exiting @ tick %i because %s' % (m5.curTick(), exit_event.getCause()))

--- a/part2/parameters.rst
+++ b/part2/parameters.rst
@@ -348,7 +348,7 @@ You can have a default, or not, just like a normal parameter.
 
 The updated ``HelloObject.py`` file can be downloaded :download:`here <../_static/scripts/part2/parameters/HelloObject.py>`
 
-Second, we will add a reference to a ``GoodbyeObject`` to the ``HelloObject`` class.
+Second, we will add a pointer to a ``GoodbyeObject`` to the ``HelloObject`` class.
 
 .. code-block:: c++
 
@@ -360,13 +360,13 @@ Second, we will add a reference to a ``GoodbyeObject`` to the ``HelloObject`` cl
         EventWrapper<HelloObject, &HelloObject::processEvent> event;
 
         /// Pointer to the corresponding GoodbyeObject. Set via Python
-        const GoodbyeObject* goodbye;
+        GoodbyeObject* goodbye;
 
         /// The name of this object in the Python config file
-        const std::string myName;
+        std::string myName;
 
         /// Latency between calling the event (in ticks)
-        const Tick latency;
+        Tick latency;
 
         /// Number of times left to fire the event before goodbye
         int timesLeft;
@@ -413,7 +413,7 @@ Once we have processed the number of event specified by the parameter, we should
 
         if (timesLeft <= 0) {
             DPRINTF(Hello, "Done firing!\n");
-            goodbye.sayGoodbye(myName);
+            goodbye->sayGoodbye(myName);
         } else {
             schedule(event, curTick() + latency);
         }


### PR DESCRIPTION
Hi Jason,

Thanks for your advice. I make a new branch and separate the changes into several commits. The following are details about the changes:

- Update getMatserPort() and getSlavePort() to getPort() in simple_cache and simple_memobj because they are no longer used.
- Modify simple_cache.cc,  hello_object.cc and hello_object.hh which would cause compile errors with the original code.
- Use Python3 print style
- Update description files because of the above changes.