### PR TITLE
Fix typo in part5 - createCacheHierarchy

### DIFF
--- a/part5/fs_config.rst
+++ b/part5/fs_config.rst
@@ -240,8 +240,8 @@ You can simply import that file to use those caches.
         self.cpu.dcache.connectBus(self.membus)
 
         # Connect the CPU TLBs directly to the mem.
-        self.cpu.itb.walker.port = self.mmubus.slave
-        self.cpu.dtb.walker.port = self.mmubus.slave
+        self.cpu.itb.walker.port = self.membus.slave
+        self.cpu.dtb.walker.port = self.membus.slave
 
 After creating the cache hierarchy, next we need to create the memory controllers.
 In this configuration file, it is very simple.


### PR DESCRIPTION
A typing error in materials of part5 was fixed.
changes are applied to part5/fs_system.rst, createCacheHierarchy function.
This PR will resolve issue #33 .