### PR TITLE
Update for gem5@mem: Make MemCtrl a ClockedObject

### DIFF
--- a/part1/simple_config.rst
+++ b/part1/simple_config.rst
@@ -166,8 +166,9 @@ For this system, we'll use a simple DDR3 controller and it will be responsible f
 
 .. code-block:: python
 
-  system.mem_ctrl = DDR3_1600_8x8()
-  system.mem_ctrl.range = system.mem_ranges[0]
+  system.mem_ctrl = MemCtrl()
+  system.mem_ctrl.dram = DDR3_1600_8x8()
+  system.mem_ctrl.dram.range = system.mem_ranges[0]
   system.mem_ctrl.port = system.membus.master
 
 After those final connections, we've finished instantiating our simulated system!

--- a/part2/memoryobject.rst
+++ b/part2/memoryobject.rst
@@ -707,8 +707,9 @@ However, instead of connecting the CPU directly to the memory bus, we are going 
     system.cpu.interrupts[0].int_master = system.membus.slave
     system.cpu.interrupts[0].int_slave = system.membus.master
 
-    system.mem_ctrl = DDR3_1600_8x8()
-    system.mem_ctrl.range = system.mem_ranges[0]
+    system.mem_ctrl = MemCtrl()
+    system.mem_ctrl.dram = DDR3_1600_8x8()
+    system.mem_ctrl.dram.range = system.mem_ranges[0]
     system.mem_ctrl.port = system.membus.master
 
     system.system_port = system.membus.slave

--- a/part5/fs_config.rst
+++ b/part5/fs_config.rst
@@ -253,10 +253,10 @@ For instance, you can have multiple memory controllers with interleaved addresse
 
     def createMemoryControllers(self):
         """ Create the memory controller for the system """
-        self.mem_cntrl = DDR3_1600_8x8(range = self.mem_ranges[0],
-                                       port = self.membus.master)
+        self.mem_ctrl = MemCtrl(dram = DDR3_1600_8x8(range = self.mem_ranges[0]),
+                                 port = self.membus.master)
 
-Finally, we we create the interrupt controllers for the CPU.
+Finally, we create the interrupt controllers for the CPU.
 Again, this is the same as when we were using syscall emulation mode and is straightforward.
 
 .. code-block:: python


### PR DESCRIPTION
Fix some bitrot. The changes for part1 and part2 are copied from gem5/configs/learning_gem/*. The change for part5 was manually derived and hasn't been tested (although the prior part5 script was broken anyway with a typo, so not doing any worse).